### PR TITLE
fix(challenge-utils): update `filterByUsers` to use `userId`

### DIFF
--- a/src/utils/challenge/filter.js
+++ b/src/utils/challenge/filter.js
@@ -173,8 +173,11 @@ function filterByUpcoming(challenge, state) {
 }
 
 function filterByUsers(challenge, state) {
-  if (!state.userChallenges) return true;
-  return state.userChallenges.find(ch => challenge.id === ch);
+  const userId = _.get(state, 'userId', null);
+  if (userId) {
+    return _.get(challenge, ['users', userId], false);
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
Update `filterByUsers` function to use `challenge.users[userId]` property
instead of `userChallenges` for filtering.

Addresses topcoder-platform/community-app#4782