### PR TITLE
TSJR-27 - add deprecation warning for the old api skills

### DIFF
--- a/src/services/members.js
+++ b/src/services/members.js
@@ -73,7 +73,7 @@ class MembersService {
    * @deprecated This method is using the old API skills, and the returned skills may not be what you're looking for
    * @todo Replace this method and use the new standardized skills when needed
    * @see https://topcoder.atlassian.net/browse/TSJR-27
-   * 
+   *
    * Gets member skills.
    * @param {String} handle
    * @return {Promise} Resolves to the stats object.

--- a/src/services/members.js
+++ b/src/services/members.js
@@ -70,7 +70,8 @@ class MembersService {
   }
 
   /**
-   * @deprecated This method is using the old API skills, and the returned skills may not be what you're looking for
+   * @deprecated This method is using the old API skills,
+   *  and the returned skills may not be what you're looking for
    * @todo Replace this method and use the new standardized skills when needed
    * @see https://topcoder.atlassian.net/browse/TSJR-27
    *

--- a/src/services/members.js
+++ b/src/services/members.js
@@ -70,6 +70,10 @@ class MembersService {
   }
 
   /**
+   * @deprecated This method is using the old API skills, and the returned skills may not be what you're looking for
+   * @todo Replace this method and use the new standardized skills when needed
+   * @see https://topcoder.atlassian.net/browse/TSJR-27
+   * 
    * Gets member skills.
    * @param {String} handle
    * @return {Promise} Resolves to the stats object.


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/TSJR-27
Adds deprecation warning messaging for the `member.getSkills()` method.